### PR TITLE
Fix postponed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,11 @@
 
 ### Fixed
 
+- Fixed display of postponed games with the new NHL API.
+
 ### Added
 
 ### Changed
-
-- Update workflows.
-- Update devDependencies.
-- Update lint process.
-- Lint files.
 
 ### Removed
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -40,6 +40,7 @@ const BASE_PLAYOFF_URL = 'https://api-web.nhle.com/v1/playoff-series/carousel';
  * @property {string} timestamp - Start date of the game in UTC timezone.
  * @property {string} gameDay - Game day in format YYYY-MM-DD in north american timezone.
  * @property {string} gameState - Contains information about the game status, e.g. OFF, LIVE, CRIT, FUT.
+ * @property {string} gameScheduleState - Contains specialized information about the scheduling of this game, e.g. OK, PPD (postponed)
  * @property {Team} awayTeam - Contains information about the away team.
  * @property {Team} homeTeam - Contains information about the home team.
  * @property {object} periodDescriptor - Contains information about the period of play of the game. Is present on all games, past, present, and future.
@@ -421,6 +422,7 @@ module.exports = NodeHelper.create({
             timestamp: game.startTimeUTC,
             gameDay: game.gameDay,
             status: game.gameState,
+            scheduleStatus: game.gameScheduleState,
             teams: {
                 away: this.parseTeam(game.awayTeam),
                 home: this.parseTeam(game.homeTeam),

--- a/templates/MMM-NHL.njk
+++ b/templates/MMM-NHL.njk
@@ -21,8 +21,7 @@
                     <td>
                         {% if games[index].status === "PRE" %}
                             {{ "PRE_GAME" | translate }}
-                        {# TODO: Find out what the state postponed state is in the new API #}
-                        {% elif games[index].status === "Postponed" %}
+                        {% elif games[index].scheduleStatus === "PPD" %}
                             {{ "POSTPONED" | translate }}
                         {% elif games[index].status === "FUT" %}
                             {{ games[index] | formatStartDate }}

--- a/translations/en.json
+++ b/translations/en.json
@@ -11,6 +11,6 @@
   "FINAL_OT": "Final (OT)",
   "FINAL_SO": "Final (SO)",
   "TIME_LEFT": "{TIME} left",
-  "POSTPONED": "PPD",
+  "POSTPONED": "Postponed",
   "SERIES": "Series"
 }


### PR DESCRIPTION
This updates to recognize and react to postponed games with the 2024 NHL API. gameState is still FUT for these games, but gameScheduleState is PPD (as opposed to OK for non-postponed games).